### PR TITLE
added scripts used for CMSHLT-3096 and HLT-throughput measurements via the timing server

### DIFF
--- a/fog/compareSmartPrescales.py
+++ b/fog/compareSmartPrescales.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+import os
+import sys
+
+from HLTrigger.Configuration.common in producers_by_type
+
+os.system(f'hltConfigFromDB --configName {sys.argv[1]} > hlt0.py')
+from hlt0 import cms,process as hlt0
+
+os.system(f'hltConfigFromDB --configName {sys.argv[2]} > hlt1.py')
+from hlt1 import process as hlt1
+
+def smartPrescaleMap(process):
+
+
+
+    ret = {}
+    for prod in producers_by_type(process, 'TriggerResultsFilter'):
+        if not prod.label().startswith('hltDataset'):
+            continue
+        datasetName = prod.label()[len('hltDataset'):]
+        ret[datasetName] = []
+        for trigCond in prod.triggerConditions:
+            trigCond_split = trigCond.split(' / ')
+
+            pathName = trigCond_split[0] if len(trigCond_split) > 0
+
+            ret[datasetName] += [[pathNameUnv, smartPrescaleStr]]
+
+
+paths = sorted(list(set([foo for foo in hlt.paths_()])))
+for foo in paths:
+  if foo in grun.paths_(): continue
+  if foo in hion.paths_(): continue
+  if foo in pref.paths_(): continue
+  if foo in pion.paths_(): continue
+  if foo in spec.paths_(): continue
+  print(foo[:foo.rfind('_v')+2] if '_v' in foo else foo)

--- a/hltTests/hlt2336.py
+++ b/hltTests/hlt2336.py
@@ -1,1 +1,0 @@
-/work/missiroli_m/test/tsg/storm/fix_dqm_binrange/CMSSW_12_5_X_2022-06-17-2300/src/hlt.py

--- a/hltTests/hlt2336_2.py
+++ b/hltTests/hlt2336_2.py
@@ -1,1 +1,0 @@
-/work/missiroli_m/test/tsg/storm/fix_dqm_binrange/CMSSW_12_5_X_2022-06-17-2300/src/hlt2.py

--- a/hltTests/testCMSHLT3096_0.sh
+++ b/hltTests/testCMSHLT3096_0.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+hltGetConfiguration /dev/CMSSW_14_0_0/GRun \
+   --globaltag auto:phase1_2024_realistic \
+   --mc \
+   --no-prescale \
+   --max-events 100 \
+   --input /store/mc/Run3Winter24Digi/TT_TuneCP5_13p6TeV_powheg-pythia8/GEN-SIM-RAW/133X_mcRun3_2024_realistic_v8-v2/80000/dc984f7f-2e54-48c4-8950-5daa848b6db9.root \
+   --customise HLTrigger/Configuration/customizeHLTforAlpaka.customizeHLTforAlpaka \
+   --eras Run3 --l1-emulator uGT --l1 L1Menu_Collisions2024_v1_0_0_xml \
+   > hlt.py
+
+cat <<@EOF >> hlt.py
+for out_mod_label, out_mod in process.outputModules_().items():
+  try: out_mod.SelectEvents.SelectEvents = ['HLTriggerFirstPath']
+  except: pass
+@EOF
+
+edmConfigDump hlt.py > hlt_dump.py
+
+cmsRun hlt.py &> hlt.log

--- a/hltTests/testCMSHLT3096_1.sh
+++ b/hltTests/testCMSHLT3096_1.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+hltGetConfiguration /users/missirol/test/dev/CMSSW_14_0_0/tmp/240303_firstAlpakaMenu/Test03/GRun \
+   --globaltag auto:phase1_2024_realistic \
+   --mc \
+   --no-prescale \
+   --max-events 100 \
+   --input /store/mc/Run3Winter24Digi/TT_TuneCP5_13p6TeV_powheg-pythia8/GEN-SIM-RAW/133X_mcRun3_2024_realistic_v8-v2/80000/dc984f7f-2e54-48c4-8950-5daa848b6db9.root \
+   --eras Run3 --l1-emulator uGT --l1 L1Menu_Collisions2024_v1_0_0_xml \
+   > hlt1.py
+
+#   --customise HLTrigger/Configuration/customizeHLTforAlpaka.customizeHLTforAlpaka \
+
+cat <<@EOF >> hlt1.py
+for out_mod_label, out_mod in process.outputModules_().items():
+  try: out_mod.SelectEvents.SelectEvents = ['HLTriggerFirstPath']
+  except: pass
+
+#process.hltHbheRecHitSoA.src = cms.InputTag( process.hltHbheRecHitSoA.src.value() )
+#process.hltHbheRecHitSoACPUSerial = process.hltHbheRecHitSoA.clone(
+#    alpaka = dict(backend = 'serial_sync'),
+#)
+#
+#process.hltParticleFlowRecHitHBHESoA.topology = cms.ESInputTag( process.hltParticleFlowRecHitHBHESoA.topology.value() )
+#
+#process.hltParticleFlowRecHitHBHESoA.producers = cms.VPSet(
+#    cms.PSet(
+#        src = cms.InputTag("hltHbheRecHitSoA"),
+#        params = cms.ESInputTag("hltESPPFRecHitHCALParams:"),
+#    )
+#)
+#
+#process.hltParticleFlowRecHitHBHE.src = cms.InputTag( process.hltParticleFlowRecHitHBHE.src.value() )
+#process.hltParticleFlowRecHitHBHECPUOnly = process.hltParticleFlowRecHitHBHE.clone(
+#    src = 'hltParticleFlowRecHitHBHESoACPUSerial',
+#)
+#
+#process.hltParticleFlowRecHitHBHESoACPUSerial = process.hltParticleFlowRecHitHBHESoA.clone(alpaka = dict(backend = 'serial_sync'))
+#process.hltParticleFlowRecHitHBHESoACPUSerial.producers[0].src = 'hltHbheRecHitSoACPUSerial'
+#
+#process.hltParticleFlowClusterHBHESoA = cms.EDProducer("PFClusterSoAProducer@alpaka",
+#    pfRecHits = cms.InputTag("hltParticleFlowRecHitHBHESoA"),
+#    topology = cms.ESInputTag("hltESPPFRecHitHCALTopology:"),
+#    pfClusterParams = cms.ESInputTag("hltESPPFClusterParams:"),
+#    synchronise = cms.bool(False),
+#    alpaka = cms.untracked.PSet(
+#        backend = cms.untracked.string('')
+#    )
+#)
+#
+#process.hltParticleFlowClusterHBHESoACPUSerial = process.hltParticleFlowClusterHBHESoA.clone(
+#    pfRecHits = 'hltParticleFlowRecHitHBHESoACPUSerial',
+#    alpaka = dict(backend = 'serial_sync'),
+#)
+@EOF
+
+edmConfigDump hlt1.py > hlt1_dump.py
+
+cmsRun hlt1.py &> hlt1.log

--- a/hltTests/testCMSHLT3096_2.sh
+++ b/hltTests/testCMSHLT3096_2.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+jobName=hlt_alpaka_test05
+
+hltConfigFromDB --configName /dev/CMSSW_14_0_0/HLT > tmp.py
+
+edmConfigDump tmp.py > "${jobName}"_ref.py
+
+cat <<@EOF >> tmp.py
+from HLTrigger.Configuration.customizeHLTforAlpaka import customizeHLTforAlpaka
+process = customizeHLTforAlpaka(process)
+@EOF
+
+edmConfigDump tmp.py > "${jobName}".py

--- a/hltTests/testCMSHLT3096_3.sh
+++ b/hltTests/testCMSHLT3096_3.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+jobName=hlt_alpaka_test14
+
+hltConfigFromDB --configName /dev/CMSSW_14_0_0/HLT > tmp.py
+
+edmConfigDump tmp.py > "${jobName}"_ref.py
+
+cat <<@EOF >> tmp.py
+from HLTrigger.Configuration.customizeHLTforAlpaka import customizeHLTforAlpaka
+process = customizeHLTforAlpaka(process)
+@EOF
+
+edmConfigDump tmp.py > "${jobName}".py
+
+cat <<@EOF >> tmp.py
+from HLTrigger.Configuration.customizeHLTforAlpaka import customizeHLTforAlpaka
+process = customizeHLTforAlpaka(process)
+@EOF
+
+edmConfigDump tmp.py > "${jobName}"_2.py
+
+cat <<@EOF >> tmp.py
+from HLTrigger.Configuration.customizeHLTforAlpaka import customizeHLTforAlpaka
+process = customizeHLTforAlpaka(process)
+@EOF
+
+edmConfigDump tmp.py > "${jobName}"_3.py

--- a/hltTests/testCMSHLT3096_4.sh
+++ b/hltTests/testCMSHLT3096_4.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# V82 + customizeHLTforAlpaka
+hltConfigFromDB --configName /dev/CMSSW_14_0_0/HLT/V82 > tmp.py
+
+cat <<@EOF >> tmp.py
+from HLTrigger.Configuration.customizeHLTforAlpaka import customizeHLTforAlpaka
+process = customizeHLTforAlpaka(process)
+@EOF
+
+edmConfigDump --prune tmp.py > hlt0.py
+
+# latest + customizeHLTforAlpaka
+hltConfigFromDB --configName /dev/CMSSW_14_0_0/HLT/V83 > tmp.py
+
+cat <<@EOF >> tmp.py
+from HLTrigger.Configuration.customizeHLTforAlpaka import customizeHLTforAlpaka
+process = customizeHLTforAlpaka(process)
+@EOF
+
+edmConfigDump --prune tmp.py > hlt1.py

--- a/rucio/make_rule.sh
+++ b/rucio/make_rule.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+[ $# -eq 1 ] || exit 1
+
+block="cms:${1}"
+shift
+
+source /cvmfs/cms.cern.ch/cmsset_default.sh
+source /cvmfs/cms.cern.ch/rucio/setup-py3.sh
+export RUCIO_ACCOUNT="t2_ch_cern_local_users"
+
+[ -f "${X509_USER_PROXY}" ] || voms-proxy-init -voms cms -rfc -valid 192:00
+
+account="${RUCIO_ACCOUNT}"
+lifetime=$((86400 * 150)) # Lifetime in seconds. Multiplication factor is days. 
+comment="Studies of Trigger Studies Group (HLT)"
+#block="cms:/store/data/Run2022A/MinimumBias0/RAW/v1/000/352/568/00000/d4dcc6b1-0c5d-4b89-a117-d82fbceec7d1.root" # file name
+#block="cms:/MinimumBias0/Run2022A-v1/RAW#fc8a2c55-b525-4052-b234-dcf48b9ec0f7" # block name
+copies=1
+rse_expression="T2_CH_CERN"
+
+echo "Are you sure you want to create the following rule?"
+echo "====="
+echo "Account: $account"
+echo "Comment: $comment"
+echo "RSE: $rse_expression"
+echo "Block: $block"
+echo "Copies $copies"
+echo "Lifetime: $lifetime seconds ($(expr $lifetime / 86400) days)"
+echo "====="
+
+select yn in "Yes" "No"; do
+  case $yn in
+    Yes ) rucio add-rule --account $account --lifetime $lifetime --comment "$comment" $block $copies $rse_expression ; break;;
+    No ) echo "Aborting"; break;;
+  esac
+done

--- a/steam/timing/server/readme.md
+++ b/steam/timing/server/readme.md
@@ -1,0 +1,12 @@
+# Latest Instructions
+https://gitlab.cern.ch/cms-tsg/steam/timing/-/blob/master/README.md
+https://twiki.cern.ch/twiki/bin/viewauth/CMS/TriggerStudiesTiming
+
+# Quick Setup
+```bash
+git clone https://"${USER}"@gitlab.cern.ch/cms-tsg/steam/timing.git
+python3 -m venv venv
+source venv/bin/activate
+pip3 install -r timing/requirements.txt
+python3 timing/submit.py --show
+```

--- a/steam/timing/server/setup.sh
+++ b/steam/timing/server/setup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+source venv/bin/activate

--- a/steam/timing/server/test_230324.sh
+++ b/steam/timing/server/test_230324.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+timing_dir=timing
+[ $# -lt 1 ] || timing_dir="${1}"
+
+EXE="python3 submit.py --cmssw CMSSW_14_0_X_2024-03-22-2300"
+EXE+=" --l1menu L1Menu_Collisions2024_v0_0_0_xml --event-type Run2023 --input-sample Run370293"
+EXE+=" --threads 32 --streams 24 --nrevents 30000 --jobs 8 --host srv-b1b07-16-01 --repeats 5"
+
+cd "${timing_dir}"
+
+if [ ! -f submit.py ]; then
+  exit 1
+fi
+
+foo(){
+  ${EXE} "${2}" --tag _"${1}"
+}
+
+for ntry in {1..3}; do
+
+  foo SiStripClustersOnDemand_TimingTest01_Ref1_V02_try"${ntry}" /users/missirol/test/dev/CMSSW_14_0_0/tmp/240323_SiStripClustersOnDemand/TimingTest_01/Ref1/GRun/V2
+  foo SiStripClustersOnDemand_TimingTest01_Tar1_V02_try"${ntry}" /users/missirol/test/dev/CMSSW_14_0_0/tmp/240323_SiStripClustersOnDemand/TimingTest_01/Tar1/GRun/V2
+
+done; unset nnn;

--- a/steam/timing/server/test_CMSHLT2820.sh
+++ b/steam/timing/server/test_CMSHLT2820.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+[ $# -eq 1 ] || exit 1
+
+EXE="python3 submit.py --cmssw CMSSW_13_0_6"
+EXE+=" --event-type Run2023 --input-sample Run367771 --l1menu L1Menu_Collisions2023_v1_1_0-d1_xml"
+EXE+=" --threads 32 --streams 24 --nrevents 30000 --jobs 8 --host srv-b1b07-16-01"
+
+cd ${1}
+
+for try in {0..2}; do
+  ${EXE} /dev/CMSSW_13_0_0/GRun/V111 --tag _GRunV111_try"${try}"
+  ${EXE} /users/missirol/test/dev/CMSSW_13_0_0/tmp/test16/tmp01/GRun/V2 --tag _GRunV111_withoutEXOTriggersWithRun2PixelTracking_try"${try}"
+  ${EXE} /users/missirol/test/dev/CMSSW_13_0_0/tmp/test16/tmp02/GRun/V2 --tag _GRunV111_withoutEXODisplacedTauTrigger_try"${try}"
+done

--- a/steam/timing/server/test_CMSHLT2836.sh
+++ b/steam/timing/server/test_CMSHLT2836.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+[ $# -eq 1 ] || exit 1
+
+cd ${1}
+
+if [ ! -f submit.py ]; then
+  exit 1
+fi
+
+submit(){
+  sleep 1 && python3 submit.py $@
+}
+
+OPTS="--cmssw CMSSW_13_0_10"
+OPTS+=" --event-type Run2023 --input-sample Run370293 --l1menu L1Menu_Collisions2023_v1_2_0-d1_xml"
+OPTS+=" --threads 32 --streams 24 --nrevents 30000 --jobs 8 --host srv-b1b07-16-01"
+
+for try in {2..3}; do
+  for grun in 1 2 3; do
+    submit ${OPTS} /users/missirol/test/dev/CMSSW_13_0_0/CMSHLT_2836/Test01/GRun/V"${grun}" --tag _CMSHLT2836_GRunV"${grun}"_try"${try}"
+  done
+done
+
+# for fff in $(ls /eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/timing_server_results/missirol/CMSSW_13_0_10_1300GRunV*_try*.20230721_*/cmsRun*.stderr | sort -u); do echo $fff; grep FastReport ${fff} | grep total | tail -1; done; unset fff;

--- a/steam/timing/server/test_CMSHLT3045.sh
+++ b/steam/timing/server/test_CMSHLT3045.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+timing_dir=timing
+[ $# -lt 1 ] || timing_dir="${1}"
+
+EXE="python3 submit.py --cmssw CMSSW_14_0_X_2024-03-22-2300"
+EXE+=" --l1menu L1Menu_Collisions2024_v0_0_0_xml --event-type Run2023 --input-sample Run370293"
+EXE+=" --threads 32 --streams 24 --nrevents 30000 --jobs 8 --host srv-b1b07-16-01 --repeats 5"
+
+cd "${timing_dir}"
+
+if [ ! -f submit.py ]; then
+  exit 1
+fi
+
+foo(){
+  ${EXE} "${2}" --tag _"${1}"
+}
+
+for ntry in {1..2}; do
+
+  foo CMSHLT3045_TimingTest01_Ref1_V02_try"${ntry}" /users/missirol/test/dev/CMSSW_14_0_0/CMSHLT_3045/TimingTest_01/Ref1/GRun/V2
+  foo CMSHLT3045_TimingTest01_Tar1_V02_try"${ntry}" /users/missirol/test/dev/CMSSW_14_0_0/CMSHLT_3045/TimingTest_01/Tar1/GRun/V2
+  foo CMSHLT3045_TimingTest01_Tar1_V03_try"${ntry}" /users/missirol/test/dev/CMSSW_14_0_0/CMSHLT_3045/TimingTest_01/Tar1/GRun/V3
+  foo CMSHLT3045_TimingTest01_Tar2_V04_try"${ntry}" /users/missirol/test/dev/CMSSW_14_0_0/CMSHLT_3045/TimingTest_01/Tar2/GRun/V4
+
+done; unset nnn;

--- a/steam/timing/server/test_CMSHLT3066.sh
+++ b/steam/timing/server/test_CMSHLT3066.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+timing_dir=timing
+[ $# -lt 1 ] || timing_dir="${1}"
+
+EXE="python3 submit.py --cmssw CMSSW_14_0_0"
+#EXE+=" --pull-requests silviodonato:customizeHLTFor2023 --customise  HLTrigger/Configuration/customizeHLTFor2023.customizeHLTFor2023L1TMenu_v1_1_0"
+EXE+=" --l1menu L1Menu_Collisions2024_v0_0_0_xml --event-type Run2023 --input-sample Run370293"
+EXE+=" --threads 32 --streams 24 --nrevents 30000 --jobs 8 --host srv-b1b07-16-01 --repeats 3"
+
+cd "${timing_dir}"
+
+if [ ! -f submit.py ]; then
+  exit 1
+fi
+
+foo(){
+  ${EXE} "${2}" --tag _"${1}"
+}
+
+foo GRunV37                             /dev/CMSSW_14_0_0/GRun/V37
+foo CMSHLT3066_Test01_Ref               /users/missirol/test/dev/CMSSW_14_0_0/CMSHLT_3066/Test01/Ref/HLT
+foo CMSHLT3066_Test01_Ref_ScoutingOnly  /users/missirol/test/dev/CMSSW_14_0_0/CMSHLT_3066/Test01/Ref_ScoutingOnly/HLT
+foo CMSHLT3066_Test01_Tar1              /users/missirol/test/dev/CMSSW_14_0_0/CMSHLT_3066/Test01/Tar1/HLT
+foo CMSHLT3066_Test01_Tar1_ScoutingOnly /users/missirol/test/dev/CMSSW_14_0_0/CMSHLT_3066/Test01/Tar1_ScoutingOnly/HLT
+foo CMSHLT3066_Test01_Tar2              /users/missirol/test/dev/CMSSW_14_0_0/CMSHLT_3066/Test01/Tar2/HLT
+
+foo CMSHLT3066_Test02_Ref               /users/missirol/test/dev/CMSSW_14_0_0/CMSHLT_3066/Test02/Ref/HLT
+foo CMSHLT3066_Test02_Ref_ScoutingOnly  /users/missirol/test/dev/CMSSW_14_0_0/CMSHLT_3066/Test02/Ref_ScoutingOnly/HLT
+foo CMSHLT3066_Test02_Tar1              /users/missirol/test/dev/CMSSW_14_0_0/CMSHLT_3066/Test02/Tar1/HLT
+foo CMSHLT3066_Test02_Tar1_ScoutingOnly /users/missirol/test/dev/CMSSW_14_0_0/CMSHLT_3066/Test02/Tar1_ScoutingOnly/HLT
+foo CMSHLT3066_Test02_Tar2              /users/missirol/test/dev/CMSSW_14_0_0/CMSHLT_3066/Test02/Tar2/HLT

--- a/steam/timing/server/test_CMSHLT3067.sh
+++ b/steam/timing/server/test_CMSHLT3067.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+timing_dir=timing
+[ $# -lt 1 ] || timing_dir="${1}"
+
+EXE="python3 submit.py --cmssw CMSSW_14_0_0"
+#EXE+=" --pull-requests silviodonato:customizeHLTFor2023 --customise  HLTrigger/Configuration/customizeHLTFor2023.customizeHLTFor2023L1TMenu_v1_1_0"
+EXE+=" --l1menu L1Menu_Collisions2024_v0_0_0_xml --event-type Run2023 --input-sample Run370293"
+EXE+=" --threads 32 --streams 24 --nrevents 30000 --jobs 8 --host srv-b1b07-16-01 --repeats 3"
+
+cd "${timing_dir}"
+
+if [ ! -f submit.py ]; then
+  exit 1
+fi
+
+foo(){
+  ${EXE} "${2}" --tag _"${1}"
+}
+
+foo CMSHLT3067_Test01_V02_try1 /users/missirol/test/dev/CMSSW_14_0_0/CMSHLT_3067/Test01/GRun/V2
+foo CMSHLT3067_Test01_V02_try2 /users/missirol/test/dev/CMSSW_14_0_0/CMSHLT_3067/Test01/GRun/V2
+
+foo CMSHLT3067_Test01_V03_try1 /users/missirol/test/dev/CMSSW_14_0_0/CMSHLT_3067/Test01/GRun/V3
+foo CMSHLT3067_Test01_V03_try2 /users/missirol/test/dev/CMSSW_14_0_0/CMSHLT_3067/Test01/GRun/V3

--- a/steam/timing/server/test_CMSHLT3075.sh
+++ b/steam/timing/server/test_CMSHLT3075.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+timing_dir=timing
+[ $# -lt 1 ] || timing_dir="${1}"
+
+EXE="python3 submit.py --cmssw CMSSW_14_0_X_2024-03-20-2300"
+EXE+=" --l1menu L1Menu_Collisions2024_v0_0_0_xml --event-type Run2023 --input-sample Run370293"
+EXE+=" --threads 32 --streams 24 --nrevents 30000 --jobs 8 --host srv-b1b07-16-01 --repeats 3"
+
+cd "${timing_dir}"
+
+if [ ! -f submit.py ]; then
+  exit 1
+fi
+
+foo(){
+  ${EXE} "${2}" --tag _"${1}"
+}
+
+foo ScoutingRemoveNoVtx_TimingTest01_Ref1_V02_try1 /users/missirol/test/dev/CMSSW_14_0_0/tmp/240321_ScoutingRemoveNoVtx/TimingTest_01/Ref1/GRun/V2
+foo ScoutingRemoveNoVtx_TimingTest01_Tar1_V02_try1 /users/missirol/test/dev/CMSSW_14_0_0/tmp/240321_ScoutingRemoveNoVtx/TimingTest_01/Tar1/GRun/V2
+
+foo ScoutingRemoveNoVtx_TimingTest01_Ref1_V02_try2 /users/missirol/test/dev/CMSSW_14_0_0/tmp/240321_ScoutingRemoveNoVtx/TimingTest_01/Ref1/GRun/V2
+foo ScoutingRemoveNoVtx_TimingTest01_Tar1_V02_try2 /users/missirol/test/dev/CMSSW_14_0_0/tmp/240321_ScoutingRemoveNoVtx/TimingTest_01/Tar1/GRun/V2

--- a/steam/timing/server/test_CMSHLT3089.sh
+++ b/steam/timing/server/test_CMSHLT3089.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+timing_dir=timing
+[ $# -lt 1 ] || timing_dir="${1}"
+
+EXE="python3 submit.py --cmssw CMSSW_14_0_0"
+#EXE+=" --pull-requests silviodonato:customizeHLTFor2023 --customise  HLTrigger/Configuration/customizeHLTFor2023.customizeHLTFor2023L1TMenu_v1_1_0"
+EXE+=" --l1menu L1Menu_Collisions2024_v0_0_0_xml --event-type Run2023 --input-sample Run370293"
+EXE+=" --threads 32 --streams 24 --nrevents 30000 --jobs 8 --host srv-b1b07-16-01 --repeats 3"
+
+cd "${timing_dir}"
+
+if [ ! -f submit.py ]; then
+  exit 1
+fi
+
+foo(){
+  ${EXE} "${2}" --tag _"${1}"
+}
+
+foo CMSHLT3089_Test01_V01_try1 /users/missirol/test/dev/CMSSW_14_0_0/CMSHLT_3089/Test01/GRun/V1
+foo CMSHLT3089_Test01_V01_try2 /users/missirol/test/dev/CMSSW_14_0_0/CMSHLT_3089/Test01/GRun/V1
+
+foo CMSHLT3089_Test01_V02_try1 /users/missirol/test/dev/CMSSW_14_0_0/CMSHLT_3089/Test01/GRun/V2
+foo CMSHLT3089_Test01_V02_try2 /users/missirol/test/dev/CMSSW_14_0_0/CMSHLT_3089/Test01/GRun/V2

--- a/steam/timing/server/test_CMSHLT3096.sh
+++ b/steam/timing/server/test_CMSHLT3096.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+timing_dir=timing
+[ $# -lt 1 ] || timing_dir="${1}"
+
+EXE="python3 submit.py --cmssw CMSSW_14_0_X_2024-03-22-2300"
+EXE+=" --l1menu L1Menu_Collisions2024_v0_0_0_xml --event-type Run2023 --input-sample Run370293"
+EXE+=" --threads 32 --streams 24 --nrevents 30000 --jobs 8 --host srv-b1b07-16-01 --repeats 5"
+
+cd "${timing_dir}"
+
+if [ ! -f submit.py ]; then
+  exit 1
+fi
+
+foo(){
+  ${EXE} "${2}" --tag _"${1}"
+}
+
+#foo CMSHLT3096_TimingTest02_Ref1_V03_try1 /users/missirol/test/dev/CMSSW_14_0_0/CMSHLT_3096/TimingTest_02/Ref1/GRun/V3
+#foo CMSHLT3096_TimingTest02_Ref1_V03_try2 /users/missirol/test/dev/CMSSW_14_0_0/CMSHLT_3096/TimingTest_02/Ref1/GRun/V3
+#
+#foo CMSHLT3096_TimingTest02_Tar1_V03_try1 /users/missirol/test/dev/CMSSW_14_0_0/CMSHLT_3096/TimingTest_02/Tar1/GRun/V3
+#foo CMSHLT3096_TimingTest02_Tar1_V03_try2 /users/missirol/test/dev/CMSSW_14_0_0/CMSHLT_3096/TimingTest_02/Tar1/GRun/V3
+
+#foo CMSHLT3096_TimingTest05_Ref1_V02_try1 /users/missirol/test/dev/CMSSW_14_0_0/CMSHLT_3096/TimingTest_05/Ref1/GRun/V2
+#foo CMSHLT3096_TimingTest05_Ref1_V02_try2 /users/missirol/test/dev/CMSSW_14_0_0/CMSHLT_3096/TimingTest_05/Ref1/GRun/V2
+#
+#foo CMSHLT3096_TimingTest05_Tar1_V02_try1 /users/missirol/test/dev/CMSSW_14_0_0/CMSHLT_3096/TimingTest_05/Tar1/GRun/V2
+#foo CMSHLT3096_TimingTest05_Tar1_V02_try2 /users/missirol/test/dev/CMSSW_14_0_0/CMSHLT_3096/TimingTest_05/Tar1/GRun/V2
+
+for ntry in {1..2}; do
+
+  foo CMSHLT3096_TimingTest07_Ref1_V02_try"${ntry}" /users/missirol/test/dev/CMSSW_14_0_0/CMSHLT_3096/TimingTest_07/Ref1/GRun/V2
+  foo CMSHLT3096_TimingTest07_Tar1_V02_try"${ntry}" /users/missirol/test/dev/CMSSW_14_0_0/CMSHLT_3096/TimingTest_07/Tar1/GRun/V2
+
+done; unset nnn;

--- a/steam/timing/server/test_CMSHLT3117.sh
+++ b/steam/timing/server/test_CMSHLT3117.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+timing_dir=timing
+[ $# -lt 1 ] || timing_dir="${1}"
+
+EXE="python3 submit.py --cmssw CMSSW_14_0_X_2024-03-22-2300"
+EXE+=" --l1menu L1Menu_Collisions2024_v0_0_0_xml --event-type Run2023 --input-sample Run370293"
+EXE+=" --threads 32 --streams 24 --nrevents 30000 --jobs 8 --host srv-b1b07-16-01 --repeats 5"
+
+cd "${timing_dir}"
+
+if [ ! -f submit.py ]; then
+  exit 1
+fi
+
+foo(){
+  ${EXE} "${2}" --tag _"${1}"
+}
+
+for ntry in {1..2}; do
+
+  foo CMSHLT3117_TimingTest01_Ref1_V02_try"${ntry}" /users/missirol/test/dev/CMSSW_14_0_0/CMSHLT_3117/TimingTest_01/Ref1/GRun/V2
+  foo CMSHLT3117_TimingTest01_Tar1_V02_try"${ntry}" /users/missirol/test/dev/CMSSW_14_0_0/CMSHLT_3117/TimingTest_01/Tar1/GRun/V2
+
+done; unset nnn;


### PR DESCRIPTION
https://its.cern.ch/jira/browse/CMSHLT-3096
https://gitlab.cern.ch/cms-tsg/steam/timing/-/blob/master/README.md
https://twiki.cern.ch/twiki/bin/viewauth/CMS/TriggerStudiesTiming
